### PR TITLE
Usa linguagem mais inclusiva: `autor` -> `autoria`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ seguintes arquivos:
 - [LICENSE.md](/LICENSE.md): Detalhes sobre a licença do projeto. Ela define o que você pode e não
   pode fazer com o código. Em geral, a licença permite que você use, modifique e distribua o código,
   desde que siga os termos definidos. No entanto, é importante verificar se há restrições
-  específicas, como atribuição de crédito ao autor original ou proibição de uso comercial.
+  específicas, como atribuição de crédito da autoria original ou proibição de uso comercial.
 
 Certifique-se de ler esses arquivos com atenção antes de contribuir. Se tiver qualquer dificuldade
 ou dúvida, não hesite em nos perguntar utilizando o [GitHub Discussions][github-discussions]. Toda

--- a/curadoria_coletiva/all_materials.yml
+++ b/curadoria_coletiva/all_materials.yml
@@ -1,7 +1,7 @@
 # auto-generated file, please don't change it
 
 - titulo: Introdução ao Python
-  autor: Jane Doe
+  autoria: Jane Doe
   url: https://example.com/python-course
   assuntos:
   - python
@@ -22,7 +22,7 @@
     texto: Adoro o capítulo 5! Ele explica conceitos complexos de forma clara e acessível.
   file_path: materials/example.yml
 - titulo: Avançando com Python
-  autor: John Smith
+  autoria: John Smith
   url: https://example.com/advanced-python
   assuntos:
   - desenvolvimento web

--- a/curadoria_coletiva/material_model.py
+++ b/curadoria_coletiva/material_model.py
@@ -30,7 +30,7 @@ class Material(BaseModel):
 
     Attributes:
         titulo (str): The title of the material.
-        autor (Optional[str]): The author, creator, or organization responsible for the material.
+        autoria (Optional[str]): The author, creator, or organization responsible for the material.
         url (Optional[str]): A URL link to the source of the material, if available.
         assuntos (set of SubjectEnum): A set of subjects covered in the material.
         formato (FormatEnum): The format of the material, such as video, blog post, or book.
@@ -49,7 +49,7 @@ class Material(BaseModel):
     """
 
     titulo: str
-    autor: str
+    autoria: str
     url: str
     assuntos: conset(SubjectEnum, min_length=1)
     formato: FormatEnum
@@ -67,7 +67,7 @@ class Material(BaseModel):
         json_schema_extra = {
             "example": {
                 "titulo": "Introdução ao Python",
-                "autor": "Jane Doe",
+                "autoria": "Jane Doe",
                 "url": "https://example.com/python-course",
                 "assuntos": {SubjectEnum.PYTHON, SubjectEnum.PROGRAMMING_BASICS},
                 "formato": FormatEnum.VIDEO,

--- a/curadoria_coletiva/material_template.yml
+++ b/curadoria_coletiva/material_template.yml
@@ -1,8 +1,8 @@
   # Título do material educacional
 - titulo:
 
-  # Autor, criador ou organização responsável pelo material
-  autor:
+  # Pessoa ou organização responsável pelo material
+  autoria:
 
   # Link para a fonte do material
   url:

--- a/curadoria_coletiva/materials/example.yml
+++ b/curadoria_coletiva/materials/example.yml
@@ -1,5 +1,5 @@
 - titulo: Introdução ao Python
-  autor: Jane Doe
+  autoria: Jane Doe
   url: https://example.com/python-course
   assuntos:
     - python

--- a/curadoria_coletiva/materials/example2.yml
+++ b/curadoria_coletiva/materials/example2.yml
@@ -1,5 +1,5 @@
 - titulo: Avançando com Python
-  autor: John Smith
+  autoria: John Smith
   url: https://example.com/advanced-python
   assuntos:
     - desenvolvimento web


### PR DESCRIPTION
Um detalhe para a gente transparecer mais ainda o foco em inclusão ; )

Como não temos testes, testei rodando o servidor localmente mesmo:

![image](https://github.com/user-attachments/assets/7add1bd6-f84e-4708-b27c-a1c45f3cd7c2)
